### PR TITLE
USI-LS Rebalance and additional parts

### DIFF
--- a/GameData/StationPartsExpansionRedux/Patches/SSPXR-CTT.cfg
+++ b/GameData/StationPartsExpansionRedux/Patches/SSPXR-CTT.cfg
@@ -163,3 +163,9 @@
 {
   @TechRequired = colonization
 }
+
+// 5m Centrifuge
+@PART[sspx-expandable-centrifuge-5-1]:NEEDS[CommunityTechTree]:FOR[StationPartsExpansionRedux]
+{
+	@TechRequired = advColonization
+}

--- a/GameData/StationPartsExpansionRedux/Patches/SSPXR-USILS.cfg
+++ b/GameData/StationPartsExpansionRedux/Patches/SSPXR-USILS.cfg
@@ -2,10 +2,16 @@
 // Authored by KSP forum user Pulsar
 // Special thanks to KSP forum user Domfluff for advices!
 // Updated to the new USI-LS spec by forum user Boamere
+// Updated to latest USI-LS balance by forum user ProgorMatic
 
-//RIGID HABITATS
-//PTD-5 'Sunrise' Habitation Module
-@PART[sspx-habitation-125-1]:NEEDS[USILifeSupport]
+//SMALL HABITATS (2.5m or less get 1 ton bays)
+//PAS-5 'Sunrise' Habitation Module
+//PMA-5B 'Evening' Habitation Module
+//PMA-5 'Dawn' Habitation Module
+//PTD-E-1A 'Volleyball' Inflatable Habitation Module
+//PTD-E-1B 'Winston' Inflatable Habitation Module
+//PTD-E-2 'Eclair' Inflatable Habitation Module
+@PART[sspx-habitation-125-1|sspx-habitation-1875-2|sspx-habitation-1875-1|sspx-inflatable-hab-125-2|sspx-inflatable-hab-125-3|sspx-inflatable-hab-125-1]:NEEDS[USILifeSupport]
 {
 	MODULE
 	{
@@ -25,167 +31,99 @@
 	MODULE 
 	{
 		name = USILS_HabitationSwapOption
-		ConverterName = #LOC_SSPXR_Switcher_ModuleHabitation_ConverterName // #LOC_SSPXR_Switcher_ModuleHabitation_ConverterName = Habitat
-		StartActionName = #LOC_SSPXR_Switcher_ModuleHabitation_StartActionName // #LOC_SSPXR_Switcher_ModuleHabitation_StartActionName = Start Habitat
-		StopActionName = #LOC_SSPXR_Switcher_ModuleHabitation_StopActionName // #LOC_SSPXR_Switcher_ModuleHabitation_StopActionName = Stop Habitat		
+		ConverterName = Hab-Common
+		StartActionName = Start Hab-Common
+		StopActionName = Stop Hab-Common
 
-		BaseKerbalMonths = 5
-		CrewCapacity = 2
+		BaseKerbalMonths = 3
+		CrewCapacity = 3
+		BaseHabMultiplier = 0.75
+
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 0.22
+		}
+	}
+	MODULE 
+	{
+		name = USILS_HabitationSwapOption
+		ConverterName = Hab-Quarters
+		StartActionName = Start Hab-Quarters
+		StopActionName = Stop Hab-Quarters
+
+		BaseKerbalMonths = 12
+		CrewCapacity = 0
 		BaseHabMultiplier = 0
 
 		INPUT_RESOURCE
 		{
 			ResourceName = ElectricCharge
-			Ratio = 0.125
+			Ratio = 0.11
 		}
 	}
 }
-// PMA-5B 'Evening' Habitation Module
-@PART[sspx-habitation-1875-2]:NEEDS[USILifeSupport]
+@PART[sspx-habitation-1875-2|sspx-habitation-1875-1|sspx-inflatable-hab-125-1]:NEEDS[USILifeSupport]
 {
 	MODULE
 	{
-		name = USI_SwapController
-	}
-	MODULE
-	{
 		name = USI_SwappableBay
-		bayName = Bay 1
-		moduleIndex = 0
+		bayName = Bay 2
+		moduleIndex = 1
 	}
 	MODULE
 	{
 		name = USI_Converter
 		UseSpecialistBonus = false
 	}
-	MODULE 
-	{
-		name = USILS_HabitationSwapOption
-		ConverterName = #LOC_SSPXR_Switcher_ModuleHabitation_ConverterName // #LOC_SSPXR_Switcher_ModuleHabitation_ConverterName = Habitat
-		StartActionName = #LOC_SSPXR_Switcher_ModuleHabitation_StartActionName // #LOC_SSPXR_Switcher_ModuleHabitation_StartActionName = Start Habitat
-		StopActionName = #LOC_SSPXR_Switcher_ModuleHabitation_StopActionName // #LOC_SSPXR_Switcher_ModuleHabitation_StopActionName = Stop Habitat	
-
-		BaseKerbalMonths = 9
-		CrewCapacity = 3
-		BaseHabMultiplier = 0.4
-
-		INPUT_RESOURCE
-		{
-			ResourceName = ElectricCharge
-			Ratio = 0.5
-		}
-	}
 }
-// PMA-5 'Dawn' Habitation Module
 @PART[sspx-habitation-1875-1]:NEEDS[USILifeSupport]
 {
 	MODULE
 	{
-		name = USI_SwapController
-	}
-	MODULE
-	{
 		name = USI_SwappableBay
-		bayName = Bay 1
-		moduleIndex = 0
+		bayName = Bay 3
+		moduleIndex = 2
 	}
 	MODULE
 	{
 		name = USI_Converter
 		UseSpecialistBonus = false
 	}
-	MODULE 
-	{
-		name = USILS_HabitationSwapOption
-		ConverterName = #LOC_SSPXR_Switcher_ModuleHabitation_ConverterName // #LOC_SSPXR_Switcher_ModuleHabitation_ConverterName = Habitat
-		StartActionName = #LOC_SSPXR_Switcher_ModuleHabitation_StartActionName // #LOC_SSPXR_Switcher_ModuleHabitation_StartActionName = Start Habitat
-		StopActionName = #LOC_SSPXR_Switcher_ModuleHabitation_StopActionName // #LOC_SSPXR_Switcher_ModuleHabitation_StopActionName = Stop Habitat	
-
-		BaseKerbalMonths = 25
-		CrewCapacity = 5
-		BaseHabMultiplier = 0.8
-
-		INPUT_RESOURCE
-		{
-			ResourceName = ElectricCharge
-			Ratio = 1
-		}
-	}
 }
+@PART[sspx-habitation-125-1]:NEEDS[KolonyTools]
+{
+	@mass = 1
+}
+@PART[sspx-habitation-1875-2]:NEEDS[KolonyTools]
+{
+	@mass = 2
+}
+@PART[sspx-habitation-1875-1]:NEEDS[KolonyTools]
+{
+	@mass = 3
+}
+@PART[sspx-inflatable-hab-125-2]:NEEDS[KolonyTools]
+{
+	@mass = 0.75
+}
+@PART[sspx-inflatable-hab-125-3]:NEEDS[KolonyTools]
+{
+	@mass = 0.6
+}
+@PART[sspx-inflatable-hab-125-1]:NEEDS[KolonyTools]
+{
+	@mass = 1.5
+}
+//LARGE HABITATS (2.5m+ get 2 ton bays)
 //PPD-20 'Shanty' Habitation Module
-@PART[sspx-habitation-25-1]:NEEDS[USILifeSupport]
-{
-	MODULE
-	{
-		name = USI_SwapController
-	}
-	MODULE
-	{
-		name = USI_SwappableBay
-		bayName = Bay 1
-		moduleIndex = 0
-	}
-	MODULE
-	{
-		name = USI_Converter
-		UseSpecialistBonus = false
-	}
-	MODULE 
-	{
-		name = USILS_HabitationSwapOption
-		ConverterName = #LOC_SSPXR_Switcher_ModuleHabitation_ConverterName // #LOC_SSPXR_Switcher_ModuleHabitation_ConverterName = Habitat
-		StartActionName = #LOC_SSPXR_Switcher_ModuleHabitation_StartActionName // #LOC_SSPXR_Switcher_ModuleHabitation_StartActionName = Start Habitat
-		StopActionName = #LOC_SSPXR_Switcher_ModuleHabitation_StopActionName // #LOC_SSPXR_Switcher_ModuleHabitation_StopActionName = Stop Habitat	
-
-		BaseKerbalMonths = 28
-		CrewCapacity = 6
-		BaseHabMultiplier = 1
-
-		INPUT_RESOURCE
-		{
-			ResourceName = ElectricCharge
-			Ratio = 1.2
-		}
-	}
-}
-//PXL-1 'Hostel' Deep-Space Habitation Module
-@PART[sspx-habitation-375-1]:NEEDS[USILifeSupport]
-{
-	MODULE
-	{
-		name = USI_SwapController
-	}
-	MODULE
-	{
-		name = USI_SwappableBay
-		bayName = Bay 1
-		moduleIndex = 0
-	}
-	MODULE
-	{
-		name = USI_Converter
-		UseSpecialistBonus = false
-	}
-	MODULE 
-	{
-		name = USILS_HabitationSwapOption
-		ConverterName = #LOC_SSPXR_Switcher_ModuleHabitation_ConverterName // #LOC_SSPXR_Switcher_ModuleHabitation_ConverterName = Habitat
-		StartActionName = #LOC_SSPXR_Switcher_ModuleHabitation_StartActionName // #LOC_SSPXR_Switcher_ModuleHabitation_StartActionName = Start Habitat
-		StopActionName = #LOC_SSPXR_Switcher_ModuleHabitation_StopActionName // #LOC_SSPXR_Switcher_ModuleHabitation_StopActionName = Stop Habitat		
-
-		BaseKerbalMonths = 95
-		CrewCapacity = 12
-		BaseHabMultiplier = 1.9
-
-		INPUT_RESOURCE
-		{
-			ResourceName = ElectricCharge
-			Ratio = 3.325
-		}
-	}
-}
+//PXL-3 'Asylum' Storm Cellar Module
 //PXL-2 'Shelter' Deep-Space Habitation Module
-@PART[sspx-habitation-375-2]:NEEDS[USILifeSupport]
+//PXL-1 'Hostel' Deep-Space Habitation Module
+//SDV-2B 'Titan' Compact Deep Space Habitation Module
+//PPF-B 'Blimp' Inflatable Habitation Module
+//SDV-G3 'Domus' Habitation Dome
+@PART[sspx-habitation-25-1|sspx-habitation-375-3|sspx-habitation-375-2|sspx-habitation-375-1|sspx-habitation-5-2|sspx-inflatable-hab-25-2|sspx-dome-habitation-5-1]:NEEDS[USILifeSupport]
 {
 	MODULE
 	{
@@ -202,26 +140,226 @@
 		name = USI_Converter
 		UseSpecialistBonus = false
 	}
+	MODULE
+	{
+		name = USI_SwappableBay
+		bayName = Bay 2
+		moduleIndex = 1
+	}
+	MODULE
+	{
+		name = USI_Converter
+		UseSpecialistBonus = false
+	}
 	MODULE 
 	{
 		name = USILS_HabitationSwapOption
-		ConverterName = #LOC_SSPXR_Switcher_ModuleHabitation_ConverterName // #LOC_SSPXR_Switcher_ModuleHabitation_ConverterName = Habitat
-		StartActionName = #LOC_SSPXR_Switcher_ModuleHabitation_StartActionName // #LOC_SSPXR_Switcher_ModuleHabitation_StartActionName = Start Habitat
-		StopActionName = #LOC_SSPXR_Switcher_ModuleHabitation_StopActionName // #LOC_SSPXR_Switcher_ModuleHabitation_StopActionName = Stop Habitat		
+		ConverterName = Hab-Common
+		StartActionName = Start Hab-Common
+		StopActionName = Stop Hab-Common
 
-		BaseKerbalMonths = 47
+		BaseKerbalMonths = 6
 		CrewCapacity = 6
+		BaseHabMultiplier = 0.75
+
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 0.44
+		}
+	}
+	MODULE 
+	{
+		name = USILS_HabitationSwapOption
+		ConverterName = Hab-Quarters
+		StartActionName = Start Hab-Quarters
+		StopActionName = Stop Hab-Quarters
+
+		BaseKerbalMonths = 24
+		CrewCapacity = 0
 		BaseHabMultiplier = 0
 
 		INPUT_RESOURCE
 		{
 			ResourceName = ElectricCharge
-			Ratio = 1.175
+			Ratio = 0.22
 		}
 	}
 }
-//PXL-3 'Asylum' Storm Cellar Module
-@PART[sspx-habitation-375-3]:NEEDS[USILifeSupport]
+//inflatables don't get recyclers
+@PART[sspx-habitation-25-1|sspx-habitation-375-3|sspx-habitation-375-2|sspx-habitation-375-1|sspx-habitation-5-2|sspx-dome-habitation-5-1]:NEEDS[USILifeSupport]
+{
+	MODULE
+	{
+		name = USILS_LifeSupportRecyclerSwapOption
+		ConverterName = HV Recycler
+		StartActionName = Start HV Recycler
+		StopActionName = Stop HV Recycler
+
+		CrewCapacity = 20
+		RecyclePercent = 0.6
+
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 10
+		}
+	}
+	MODULE
+	{
+		name = USILS_LifeSupportRecyclerSwapOption
+		ConverterName = HE Recycler
+		StartActionName = Start HE Recycler
+		StopActionName = Stop HE Recycler
+
+		CrewCapacity = 1
+		RecyclePercent = 0.865
+
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 35
+		}
+	}
+}
+//Hostel gets a 90% recycler
+@PART[sspx-habitation-375-1]:NEEDS[USILifeSupport]
+{
+	MODULE
+	{
+		name = USILS_LifeSupportRecyclerSwapOption
+		ConverterName = Purifier
+		StartActionName = Start Purifier
+		StopActionName = Stop Purifier
+
+		CrewCapacity = 1
+		RecyclePercent = 0.9
+
+		INPUT_RESOURCE
+		{
+			ResourceName = Water
+			Ratio = 0.00300000
+		}
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 100
+		}
+	}
+}
+//Domus gets a 93.25% recycler
+@PART[sspx-habitation-375-1]:NEEDS[USILifeSupport]
+{
+	MODULE
+	{
+		name = USILS_LifeSupportRecyclerSwapOption
+		ConverterName = Purifier
+		StartActionName = Start Purifier
+		StopActionName = Stop Purifier
+
+		CrewCapacity = 1
+		RecyclePercent = 0.9325
+
+		INPUT_RESOURCE
+		{
+			ResourceName = Water
+			Ratio = 0.00442500
+		}
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 138
+		}
+	}
+}
+@PART[sspx-habitation-375-2|sspx-habitation-375-1|sspx-habitation-5-2|sspx-inflatable-hab-25-2|sspx-dome-habitation-5-1]:NEEDS[USILifeSupport]
+{
+	MODULE
+	{
+		name = USI_SwappableBay
+		bayName = Bay 3
+		moduleIndex = 2
+	}
+	MODULE
+	{
+		name = USI_Converter
+		UseSpecialistBonus = false
+	}
+}
+@PART[sspx-habitation-375-1|sspx-inflatable-hab-25-2|sspx-dome-habitation-5-1]:NEEDS[USILifeSupport]
+{
+	MODULE
+	{
+		name = USI_SwappableBay
+		bayName = Bay 4
+		moduleIndex = 3
+	}
+	MODULE
+	{
+		name = USI_Converter
+		UseSpecialistBonus = false
+	}
+	MODULE
+	{
+		name = USI_SwappableBay
+		bayName = Bay 5
+		moduleIndex = 4
+	}
+	MODULE
+	{
+		name = USI_Converter
+		UseSpecialistBonus = false
+	}
+	MODULE
+	{
+		name = USI_SwappableBay
+		bayName = Bay 6
+		moduleIndex = 5
+	}
+	MODULE
+	{
+		name = USI_Converter
+		UseSpecialistBonus = false
+	}
+}
+@PART[sspx-habitation-375-1]:NEEDS[USILifeSupport]
+{
+	MODULE
+	{
+		name = USI_SwappableBay
+		bayName = Bay 7
+		moduleIndex = 6
+	}
+	MODULE
+	{
+		name = USI_Converter
+		UseSpecialistBonus = false
+	}
+}
+@PART[sspx-habitation-25-1|sspx-habitation-375-3]:NEEDS[KolonyTools]
+{
+	@mass = 4
+}
+@PART[sspx-habitation-375-2|sspx-habitation-5-2]:NEEDS[KolonyTools]
+{
+	@mass = 6
+}
+@PART[sspx-habitation-375-1]:NEEDS[KolonyTools]
+{
+	@mass = 14
+}
+@PART[sspx-inflatable-hab-25-2]:NEEDS[KolonyTools]
+{
+	@mass = 9
+}
+@PART[sspx-dome-habitation-5-1]:NEEDS[KolonyTools]
+{
+	@mass = 12
+}
+//JUMBO HABITATS (large 5m get 4 ton bays)
+//SDV-2 'Atlas' Deep Space Habitation Module
+//PPF-A 'Dirigible' Inflatable Habitation Module
+@PART[sspx-habitation-5-1|sspx-inflatable-hab-25-1]:NEEDS[USILifeSupport]
 {
 	MODULE
 	{
@@ -238,27 +376,575 @@
 		name = USI_Converter
 		UseSpecialistBonus = false
 	}
+	MODULE
+	{
+		name = USI_SwappableBay
+		bayName = Bay 2
+		moduleIndex = 1
+	}
+	MODULE
+	{
+		name = USI_Converter
+		UseSpecialistBonus = false
+	}
+	MODULE
+	{
+		name = USI_SwappableBay
+		bayName = Bay 3
+		moduleIndex = 2
+	}
+	MODULE
+	{
+		name = USI_Converter
+		UseSpecialistBonus = false
+	}
+	MODULE
+	{
+		name = USI_SwappableBay
+		bayName = Bay 4
+		moduleIndex = 3
+	}
+	MODULE
+	{
+		name = USI_Converter
+		UseSpecialistBonus = false
+	}
+	MODULE
+	{
+		name = USI_SwappableBay
+		bayName = Bay 5
+		moduleIndex = 4
+	}
+	MODULE
+	{
+		name = USI_Converter
+		UseSpecialistBonus = false
+	}
 	MODULE 
 	{
 		name = USILS_HabitationSwapOption
-		ConverterName = #LOC_SSPXR_Switcher_ModuleHabitation_ConverterName // #LOC_SSPXR_Switcher_ModuleHabitation_ConverterName = Habitat
-		StartActionName = #LOC_SSPXR_Switcher_ModuleHabitation_StartActionName // #LOC_SSPXR_Switcher_ModuleHabitation_StartActionName = Start Habitat
-		StopActionName = #LOC_SSPXR_Switcher_ModuleHabitation_StopActionName // #LOC_SSPXR_Switcher_ModuleHabitation_StopActionName = Stop Habitat		
+		ConverterName = Hab-Common
+		StartActionName = Start Hab-Common
+		StopActionName = Stop Hab-Common
 
-		BaseKerbalMonths = 11
+		BaseKerbalMonths = 12
 		CrewCapacity = 6
-		BaseHabMultiplier = 2.6
+		BaseHabMultiplier = 1.5
 
 		INPUT_RESOURCE
 		{
 			ResourceName = ElectricCharge
-			Ratio = 1.575
+			Ratio = 0.88
+		}
+	}
+	MODULE 
+	{
+		name = USILS_HabitationSwapOption
+		ConverterName = Hab-Quarters
+		StartActionName = Start Hab-Quarters
+		StopActionName = Stop Hab-Quarters
+
+		BaseKerbalMonths = 48
+		CrewCapacity = 0
+		BaseHabMultiplier = 0
+
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 0.44
 		}
 	}
 }
+@PART[sspx-inflatable-hab-25-1]:NEEDS[USILifeSupport]
+{
+	MODULE
+	{
+		name = USI_SwappableBay
+		bayName = Bay 6
+		moduleIndex = 5
+	}
+	MODULE
+	{
+		name = USI_Converter
+		UseSpecialistBonus = false
+	}
+}
+@PART[sspx-habitation-5-1]:NEEDS[KolonyTools]
+{
+	@mass = 20
+}
+@PART[sspx-inflatable-hab-25-1]:NEEDS[KolonyTools]
+{
+	@mass = 18
+}
+//inflatables don't get recyclers
+@PART[sspx-habitation-5-1]:NEEDS[USILifeSupport]
+{
+	MODULE
+	{
+		name = USILS_LifeSupportRecyclerSwapOption
+		ConverterName = HV Recycler
+		StartActionName = Start HV Recycler
+		StopActionName = Stop HV Recycler
+
+		CrewCapacity = 40
+		RecyclePercent = 0.6
+
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 20
+		}
+	}
+	MODULE
+	{
+		name = USILS_LifeSupportRecyclerSwapOption
+		ConverterName = HE Recycler
+		StartActionName = Start HE Recycler
+		StopActionName = Stop HE Recycler
+
+		CrewCapacity = 2
+		RecyclePercent = 0.865
+
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 70
+		}
+	}
+	MODULE
+	{
+		name = USILS_LifeSupportRecyclerSwapOption
+		ConverterName = Purifier
+		StartActionName = Start Purifier
+		StopActionName = Stop Purifier
+
+		CrewCapacity = 1
+		RecyclePercent = 0.9325
+
+		INPUT_RESOURCE
+		{
+			ResourceName = Water
+			Ratio = 0.00442500
+		}
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 138
+		}
+	}
+}
+
+//CENTRIFUGES (Inflatable)
+//CAF-5 'Doughnut' Compact Inflatable Centrifuge Module
+//CAF-10 'Bagel' Inflatable Centrifuge Module
+//PPF-C 'Coriolis' Inflatable Centrifuge Module
+@PART[sspx-inflatable-centrifuge-125-2|sspx-inflatable-centrifuge-125-1|sspx-inflatable-centrifuge-25-1]:NEEDS[USILifeSupport]
+{
+	MODULE
+	{
+		name = USI_SwapController
+	}
+	MODULE
+	{
+		name = USI_SwappableBay
+		bayName = Bay 1
+		moduleIndex = 0
+	}
+	MODULE
+	{
+		name = USI_Converter
+		UseSpecialistBonus = false
+	}
+	MODULE
+	{
+		name = USI_SwappableBay
+		bayName = Bay 2
+		moduleIndex = 1
+	}
+	MODULE
+	{
+		name = USI_Converter
+		UseSpecialistBonus = false
+	}
+	MODULE 
+	{
+		name = USILS_HabitationSwapOption
+		ConverterName = Hab-Common
+		StartActionName = Start Hab-Common
+		StopActionName = Stop Hab-Common
+
+		BaseKerbalMonths = 6
+		CrewCapacity = 6
+		BaseHabMultiplier = 0.75
+
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 0.44
+		}
+	}
+	MODULE 
+	{
+		name = USILS_HabitationSwapOption
+		ConverterName = Hab-Quarters
+		StartActionName = Start Hab-Quarters
+		StopActionName = Stop Hab-Quarters
+
+		BaseKerbalMonths = 24
+		CrewCapacity = 0
+		BaseHabMultiplier = 0
+
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 0.22
+		}
+	}
+	MODULE
+	{
+		name = USILS_LifeSupportRecyclerSwapOption
+		ConverterName = HV Recycler
+		StartActionName = Start HV Recycler
+		StopActionName = Stop HV Recycler
+
+		CrewCapacity = 20
+		RecyclePercent = 0.6
+
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 10
+		}
+	}
+}
+@PART[sspx-inflatable-centrifuge-125-1|sspx-inflatable-centrifuge-25-1]:NEEDS[USILifeSupport]
+{
+	MODULE
+	{
+		name = USI_SwapController
+	}
+	MODULE
+	{
+		name = USI_SwappableBay
+		bayName = Bay 3
+		moduleIndex = 2
+	}
+	MODULE
+	{
+		name = USI_Converter
+		UseSpecialistBonus = false
+	}
+}
+@PART[sspx-inflatable-centrifuge-25-1]:NEEDS[USILifeSupport]
+{
+	MODULE
+	{
+		name = USI_SwapController
+	}
+	MODULE
+	{
+		name = USI_SwappableBay
+		bayName = Bay 4
+		moduleIndex = 3
+	}
+	MODULE
+	{
+		name = USI_Converter
+		UseSpecialistBonus = false
+	}
+}
+@PART[sspx-inflatable-centrifuge-125-2]:NEEDS[KolonyTools]
+{
+	@mass = 4
+}
+@PART[sspx-inflatable-centrifuge-125-1]:NEEDS[KolonyTools]
+{
+	@mass = 6
+}
+@PART[sspx-inflatable-centrifuge-25-1]:NEEDS[KolonyTools]
+{
+	@mass = 8
+}
+//CENTRIFUGES (Semi-Rigid) - large parts with 6 ton bays
+//PXL-F 'Pilgrim' Extensible Centrifuge
+//PXL-E 'Mercury' Extensible Centrifuge
+//SDV-X 'Cronus' Extensible Centrifuge
+@PART[sspx-expandable-centrifuge-375-2|sspx-expandable-centrifuge-375-1|sspx-expandable-centrifuge-5-1]:NEEDS[USILifeSupport]
+{
+	MODULE
+	{
+		name = USI_SwapController
+	}
+	MODULE
+	{
+		name = USI_SwappableBay
+		bayName = Bay 1
+		moduleIndex = 0
+	}
+	MODULE
+	{
+		name = USI_Converter
+		UseSpecialistBonus = false
+	}
+	MODULE
+	{
+		name = USI_SwappableBay
+		bayName = Bay 2
+		moduleIndex = 1
+	}
+	MODULE
+	{
+		name = USI_Converter
+		UseSpecialistBonus = false
+	}
+	MODULE
+	{
+		name = USI_SwappableBay
+		bayName = Bay 3
+		moduleIndex = 2
+	}
+	MODULE
+	{
+		name = USI_Converter
+		UseSpecialistBonus = false
+	}
+	MODULE 
+	{
+		name = USILS_HabitationSwapOption
+		ConverterName = Hab-Common
+		StartActionName = Start Hab-Common
+		StopActionName = Stop Hab-Common
+
+		BaseKerbalMonths = 6
+		CrewCapacity = 6
+		BaseHabMultiplier = 2
+
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 1.32
+		}
+	}
+	MODULE 
+	{
+		name = USILS_HabitationSwapOption
+		ConverterName = Hab-Quarters
+		StartActionName = Start Hab-Quarters
+		StopActionName = Stop Hab-Quarters
+
+		BaseKerbalMonths = 72
+		CrewCapacity = 0
+		BaseHabMultiplier = 0
+
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 0.66
+		}
+	}
+	MODULE
+	{
+		name = USILS_LifeSupportExtenderSwapOption
+		ConverterName = Living Module
+		StartActionName = Start Living Module
+		StopActionName = Stop Living Module
+		
+		TimeMultiplier = 6
+		UseSpecialistBonus = false
+		
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 18
+		}	
+		INPUT_RESOURCE
+		{
+			ResourceName = ColonySupplies
+			Ratio = 0.000834
+		}	
+	}
+	MODULE
+	{
+		name = USILS_LifeSupportRecyclerSwapOption
+		ConverterName = HV Recycler
+		StartActionName = Start HV Recycler
+		StopActionName = Stop HV Recycler
+
+		CrewCapacity = 60
+		RecyclePercent = 0.6
+
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 30
+		}
+	}
+	MODULE
+	{
+		name = USILS_LifeSupportRecyclerSwapOption
+		ConverterName = HE Recycler
+		StartActionName = Start HE Recycler
+		StopActionName = Stop HE Recycler
+
+		CrewCapacity = 3
+		RecyclePercent = 0.865
+
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 105
+		}
+	}
+	MODULE
+	{
+		name = USILS_LifeSupportRecyclerSwapOption
+		ConverterName = Purifier
+		StartActionName = Start Purifier
+		StopActionName = Stop Purifier
+
+		CrewCapacity = 3
+		RecyclePercent = 0.9325
+
+		INPUT_RESOURCE
+		{
+			ResourceName = Water
+			Ratio = 0.01327500
+		}
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 414
+		}
+	}
+}
+@PART[sspx-expandable-centrifuge-375-1|sspx-expandable-centrifuge-5-1]:NEEDS[USILifeSupport]
+{
+	MODULE:NEEDS[USILifeSupport]
+	{
+		name = USILS_LifeSupportExtenderSwapOption
+		ConverterName = Medical Bay
+		StartActionName = Start Medical Bay
+		StopActionName = Stop Medical Bay
+		
+		AffectsPartOnly = false
+		RestrictedToClass = Tourist
+		TimeMultiplier = 12
+		
+		UseSpecialistBonus = true
+		ExperienceEffect = MedicalSkill
+
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 72
+		}	
+		INPUT_RESOURCE
+		{
+			ResourceName = ColonySupplies
+			Ratio = 0.003333
+		}	
+	}	
+}
+@PART[sspx-expandable-centrifuge-375-1|sspx-expandable-centrifuge-5-1]:NEEDS[USILifeSupport]
+{
+	MODULE
+	{
+		name = USI_SwapController
+	}
+	MODULE
+	{
+		name = USI_SwappableBay
+		bayName = Bay 4
+		moduleIndex = 3
+	}
+	MODULE
+	{
+		name = USI_Converter
+		UseSpecialistBonus = false
+	}
+	MODULE
+	{
+		name = USI_SwappableBay
+		bayName = Bay 5
+		moduleIndex = 4
+	}
+	MODULE
+	{
+		name = USI_Converter
+		UseSpecialistBonus = false
+	}
+}
+@PART[sspx-expandable-centrifuge-5-1]:NEEDS[USILifeSupport]
+{
+	MODULE
+	{
+		name = USI_SwapController
+	}
+	MODULE
+	{
+		name = USI_SwappableBay
+		bayName = Bay 6
+		moduleIndex = 5
+	}
+	MODULE
+	{
+		name = USI_Converter
+		UseSpecialistBonus = false
+	}
+	MODULE
+	{
+		name = USI_SwappableBay
+		bayName = Bay 7
+		moduleIndex = 6
+	}
+	MODULE
+	{
+		name = USI_Converter
+		UseSpecialistBonus = false
+	}
+	MODULE
+	{
+		name = USI_SwappableBay
+		bayName = Bay 8
+		moduleIndex = 7
+	}
+	MODULE
+	{
+		name = USI_Converter
+		UseSpecialistBonus = false
+	}
+	MODULE
+	{
+		name = USI_SwappableBay
+		bayName = Bay 9
+		moduleIndex = 8
+	}
+	MODULE
+	{
+		name = USI_Converter
+		UseSpecialistBonus = false
+	}
+}
+@PART[sspx-expandable-centrifuge-375-2]:NEEDS[KolonyTools]
+{
+	@mass = 19.8
+}
+@PART[sspx-expandable-centrifuge-375-1]:NEEDS[KolonyTools]
+{
+	@mass = 33
+}
+@PART[sspx-expandable-centrifuge-5-1]:NEEDS[KolonyTools]
+{
+	@mass = 59.4
+}
+//CUPOLA
+//PAS-C Observation Window
+//PMA-C 'Panoptes' Observation Module
 //PPD-24 'Panorama' Observation Module
 //PXL-9 Astrogation Module
-@PART[sspx-observation-25-1|sspx-cupola-375-1]:NEEDS[USILifeSupport]
+//SDV-G4 'Astrolabe' Observation Dome
+@PART[sspx-cupola-125-1|sspx-cupola-1875-1|sspx-observation-25-1|sspx-cupola-375-1|sspx-dome-cupola-5-1]:NEEDS[USILifeSupport]
 {
 	MODULE
 	{
@@ -279,10 +965,8 @@
 	{
 		name = USILS_HabitationSwapOption
 		BaseKerbalMonths = 0
-		%CrewCapacity = #$/CrewCapacity$
-		@CrewCapacity *= 2
-		%BaseHabMultiplier = #$/mass$
-		@BaseHabMultiplier *= .9
+		CrewCapacity = 6
+		BaseHabMultiplier = 1.45
 		
 		%ConverterName = #LOC_SSPXR_Switcher_ModuleHabitation_ConverterName // #LOC_SSPXR_Switcher_ModuleHabitation_ConverterName = Habitat
 		%StartActionName = #LOC_SSPXR_Switcher_ModuleHabitation_StartActionName // #LOC_SSPXR_Switcher_ModuleHabitation_StartActionName = Start Habitat
@@ -291,197 +975,57 @@
 		INPUT_RESOURCE
 		{
 			ResourceName = ElectricCharge
-			%Ratio = #$../BaseHabMultiplier$
-			@Ratio *= .5
+			%Ratio = 0.44
 		}
 	}
 }
-//PTD-C Observation Window
-@PART[sspx-cupola-125-1]:NEEDS[USILifeSupport]
+@PART[sspx-observation-25-1|sspx-cupola-375-1|sspx-dome-cupola-5-1]:NEEDS[USILifeSupport]
 {
 	MODULE
 	{
-		name = USI_SwapController
-	}
-	MODULE
-	{
 		name = USI_SwappableBay
-		bayName = Bay 1
-		moduleIndex = 0
+		bayName = Bay 2
+		moduleIndex = 1
 	}
 	MODULE
 	{
 		name = USI_Converter
 		UseSpecialistBonus = false
 	}
-
-	MODULE
-	{
-		name = USILS_HabitationSwapOption
-
-		name = USILS_HabitationSwapOption
-		ConverterName = #LOC_SSPXR_Switcher_ModuleHabitation_ConverterName // #LOC_SSPXR_Switcher_ModuleHabitation_ConverterName = Habitat
-		StartActionName = #LOC_SSPXR_Switcher_ModuleHabitation_StartActionName // #LOC_SSPXR_Switcher_ModuleHabitation_StartActionName = Start Habitat
-		StopActionName = #LOC_SSPXR_Switcher_ModuleHabitation_StopActionName // #LOC_SSPXR_Switcher_ModuleHabitation_StopActionName = Stop Habitat		
-
-		BaseKerbalMonths = 0
-		CrewCapacity = 1
-		BaseHabMultiplier = 0.7
-
-		INPUT_RESOURCE
-		{
-			ResourceName = ElectricCharge
-			Ratio = 0.1
-		}
-	}
 }
-// PMA-C 'Panoptes' Observation Module
-@PART[sspx-cupola-1875-1]:NEEDS[USILifeSupport]
+@PART[sspx-dome-cupola-5-1]:NEEDS[USILifeSupport]
 {
 	MODULE
 	{
-		name = USI_SwapController
-	}
-	MODULE
-	{
 		name = USI_SwappableBay
-		bayName = Bay 1
-		moduleIndex = 0
+		bayName = Bay 3
+		moduleIndex = 2
 	}
 	MODULE
 	{
 		name = USI_Converter
 		UseSpecialistBonus = false
 	}
-
-	MODULE
-	{
-		name = USILS_HabitationSwapOption
-
-		name = USILS_HabitationSwapOption
-		ConverterName = #LOC_SSPXR_Switcher_ModuleHabitation_ConverterName // #LOC_SSPXR_Switcher_ModuleHabitation_ConverterName = Habitat
-		StartActionName = #LOC_SSPXR_Switcher_ModuleHabitation_StartActionName // #LOC_SSPXR_Switcher_ModuleHabitation_StartActionName = Start Habitat
-		StopActionName = #LOC_SSPXR_Switcher_ModuleHabitation_StopActionName // #LOC_SSPXR_Switcher_ModuleHabitation_StopActionName = Stop Habitat		
-
-		BaseKerbalMonths = 0
-		CrewCapacity = 1
-		BaseHabMultiplier = 1.2
-
-		INPUT_RESOURCE
-		{
-			ResourceName = ElectricCharge
-			Ratio = 0.1
-		}
-	}
+}
+@PART[sspx-cupola-125-1|sspx-cupola-1875-1]:NEEDS[KolonyTools]
+{
+	@mass = 2
+}
+@PART[sspx-observation-25-1|sspx-cupola-375-1]:NEEDS[KolonyTools]
+{
+	@mass = 4
+}
+@PART[sspx-dome-cupola-5-1]:NEEDS[KolonyTools]
+{
+	@mass = 6
 }
 //STATION CORES
-//PTD-8R 'Pier' Station Core
-@PART[sspx-core-125-1]:NEEDS[USILifeSupport]
-{
-	MODULE
-	{
-		name = USI_SwapController
-	}
-	MODULE
-	{
-		name = USI_SwappableBay
-		bayName = Bay 1
-		moduleIndex = 0
-	}
-	MODULE
-	{
-		name = USI_Converter
-		UseSpecialistBonus = false
-	}
-	MODULE
-	{
-		name = USILS_LifeSupportRecyclerSwapOption
-		ConverterName = #LOC_SSPXR_Switcher_ModuleLifeSupportRecycler_ConverterName // #LOC_SSPXR_Switcher_ModuleLifeSupportRecycler_ConverterName = Life Support
-		StartActionName = #LOC_SSPXR_Switcher_ModuleLifeSupportRecycler_StartActionName // #LOC_SSPXR_Switcher_ModuleLifeSupportRecycler_StartActionName = Start Life Support
-		StopActionName = #LOC_SSPXR_Switcher_ModuleLifeSupportRecycler_StopActionName // #LOC_SSPXR_Switcher_ModuleLifeSupportRecycler_StopActionName = Stop Life Support
-
-		CrewCapacity = 2
-		RecyclePercent = 0.25
-
-		INPUT_RESOURCE
-		{
-			ResourceName = ElectricCharge
-			Ratio = 1
-		}
-	}
-}
-// PMA-2 'Quay' Station Core
-@PART[sspx-core-1875-1]:NEEDS[USILifeSupport]
-{
-	MODULE
-	{
-		name = USI_SwapController
-	}
-	MODULE
-	{
-		name = USI_SwappableBay
-		bayName = Bay 1
-		moduleIndex = 0
-	}
-	MODULE
-	{
-		name = USI_Converter
-		UseSpecialistBonus = false
-	}
-	MODULE
-	{
-		name = USILS_LifeSupportRecyclerSwapOption
-		ConverterName = #LOC_SSPXR_Switcher_ModuleLifeSupportRecycler_ConverterName // #LOC_SSPXR_Switcher_ModuleLifeSupportRecycler_ConverterName = Life Support
-		StartActionName = #LOC_SSPXR_Switcher_ModuleLifeSupportRecycler_StartActionName // #LOC_SSPXR_Switcher_ModuleLifeSupportRecycler_StartActionName = Start Life Support
-		StopActionName = #LOC_SSPXR_Switcher_ModuleLifeSupportRecycler_StopActionName // #LOC_SSPXR_Switcher_ModuleLifeSupportRecycler_StopActionName = Stop Life Support
-
-		CrewCapacity = 3
-		RecyclePercent = 0.25
-
-		INPUT_RESOURCE
-		{
-			ResourceName = ElectricCharge
-			Ratio = 1
-		}
-	}
-}
+//PAS-8R 'Pier' Station Core
+//PMA-2 'Quay' Station Core
 //PPD-8 'Wharf' Station Core
-@PART[sspx-core-25-1]:NEEDS[USILifeSupport]
-{
-	MODULE
-	{
-		name = USI_SwapController
-	}
-	MODULE
-	{
-		name = USI_SwappableBay
-		bayName = Bay 1
-		moduleIndex = 0
-	}
-	MODULE
-	{
-		name = USI_Converter
-		UseSpecialistBonus = false
-	}
-	MODULE
-	{
-		name = USILS_LifeSupportRecyclerSwapOption
-		ConverterName = #LOC_SSPXR_Switcher_ModuleLifeSupportRecycler_ConverterName // #LOC_SSPXR_Switcher_ModuleLifeSupportRecycler_ConverterName = Life Support
-		StartActionName = #LOC_SSPXR_Switcher_ModuleLifeSupportRecycler_StartActionName // #LOC_SSPXR_Switcher_ModuleLifeSupportRecycler_StartActionName = Start Life Support
-		StopActionName = #LOC_SSPXR_Switcher_ModuleLifeSupportRecycler_StopActionName // #LOC_SSPXR_Switcher_ModuleLifeSupportRecycler_StopActionName = Stop Life Support
-
-		CrewCapacity = 4
-		RecyclePercent = 0.25
-
-		INPUT_RESOURCE
-		{
-			ResourceName = ElectricCharge
-			Ratio = 1
-		}
-	}
-}
 //PXL-10 'Harbour' Station Control Centre
-@PART[sspx-core-375-1]:NEEDS[USILifeSupport]
+//SDV-3 'Minerva' Deep Space Control Module
+@PART[sspx-core-125-1|sspx-core-1875-1|sspx-core-25-1|sspx-core-375-1|sspx-core-5-1]:NEEDS[USILifeSupport]
 {
 	MODULE
 	{
@@ -505,7 +1049,7 @@
 		StartActionName = #LOC_SSPXR_Switcher_ModuleLifeSupportRecycler_StartActionName // #LOC_SSPXR_Switcher_ModuleLifeSupportRecycler_StartActionName = Start Life Support
 		StopActionName = #LOC_SSPXR_Switcher_ModuleLifeSupportRecycler_StopActionName // #LOC_SSPXR_Switcher_ModuleLifeSupportRecycler_StopActionName = Stop Life Support
 
-		CrewCapacity = 5
+		CrewCapacity = #$/CrewCapacity$
 		RecyclePercent = 0.25
 
 		INPUT_RESOURCE
@@ -516,8 +1060,9 @@
 	}
 }
 //RECYCLERS
-//PTD-6 'Star' Utility Module
-@PART[sspx-utility-125-1]:NEEDS[USILifeSupport]
+//PAS-6 'Star' Utility Module
+//PMA-3 'Spectra' Utility Module
+@PART[sspx-utility-125-1|sspx-utility-1875-1]:NEEDS[USILifeSupport]
 {
 	MODULE
 	{
@@ -537,92 +1082,56 @@
 	MODULE
 	{
 		name = USILS_LifeSupportRecyclerSwapOption
-		ConverterName = #LOC_SSPXR_Switcher_ModuleLifeSupportRecycler_ConverterName // #LOC_SSPXR_Switcher_ModuleLifeSupportRecycler_ConverterName = Life Support
-		StartActionName = #LOC_SSPXR_Switcher_ModuleLifeSupportRecycler_StartActionName // #LOC_SSPXR_Switcher_ModuleLifeSupportRecycler_StartActionName = Start Life Support
-		StopActionName = #LOC_SSPXR_Switcher_ModuleLifeSupportRecycler_StopActionName // #LOC_SSPXR_Switcher_ModuleLifeSupportRecycler_StopActionName = Stop Life Support
+		ConverterName = HV Recycler
+		StartActionName = Start HV Recycler
+		StopActionName = Stop HV Recycler
 
-		CrewCapacity = 2
-		RecyclePercent = 0.5
+		CrewCapacity = 12
+		RecyclePercent = 0.6
 
 		INPUT_RESOURCE
 		{
 			ResourceName = ElectricCharge
-			Ratio = 0.5
+			Ratio = 6
+		}
+	}
+	MODULE
+	{
+		name = USILS_LifeSupportRecyclerSwapOption
+		ConverterName = HE Recycler
+		StartActionName = Start HE Recycler
+		StopActionName = Stop HE Recycler
+
+		CrewCapacity = 1
+		RecyclePercent = 0.79
+
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 6.25
 		}
 	}
 }
-// PMA-3 'Spectra' Utility Module
+//Spectra gets second bay due to increased size and mass
 @PART[sspx-utility-1875-1]:NEEDS[USILifeSupport]
 {
 	MODULE
 	{
-		name = USI_SwapController
-	}
-	MODULE
-	{
 		name = USI_SwappableBay
-		bayName = Bay 1
-		moduleIndex = 0
+		bayName = Bay 2
+		moduleIndex = 1
 	}
 	MODULE
 	{
 		name = USI_Converter
 		UseSpecialistBonus = false
 	}
-	MODULE
-	{
-		name = USILS_LifeSupportRecyclerSwapOption
-		ConverterName = #LOC_SSPXR_Switcher_ModuleLifeSupportRecycler_ConverterName // #LOC_SSPXR_Switcher_ModuleLifeSupportRecycler_ConverterName = Life Support
-		StartActionName = #LOC_SSPXR_Switcher_ModuleLifeSupportRecycler_StartActionName // #LOC_SSPXR_Switcher_ModuleLifeSupportRecycler_StartActionName = Start Life Support
-		StopActionName = #LOC_SSPXR_Switcher_ModuleLifeSupportRecycler_StopActionName // #LOC_SSPXR_Switcher_ModuleLifeSupportRecycler_StopActionName = Stop Life Support
-
-		CrewCapacity = 4
-		RecyclePercent = 0.5
-
-		INPUT_RESOURCE
-		{
-			ResourceName = ElectricCharge
-			Ratio = 1.5
-		}
-	}
 }
-// PMA-4 'Nature' Science Lab
-@PART[sspx-science-1875-1]:NEEDS[USILifeSupport]
-{
-	MODULE
-	{
-		name = USI_SwapController
-	}
-	MODULE
-	{
-		name = USI_SwappableBay
-		bayName = Bay 1
-		moduleIndex = 0
-	}
-	MODULE
-	{
-		name = USI_Converter
-		UseSpecialistBonus = false
-	}
-	MODULE
-	{
-		name = USILS_LifeSupportRecyclerSwapOption
-		ConverterName = #LOC_SSPXR_Switcher_ModuleLifeSupportRecycler_ConverterName // #LOC_SSPXR_Switcher_ModuleLifeSupportRecycler_ConverterName = Life Support
-		StartActionName = #LOC_SSPXR_Switcher_ModuleLifeSupportRecycler_StartActionName // #LOC_SSPXR_Switcher_ModuleLifeSupportRecycler_StartActionName = Start Life Support
-		StopActionName = #LOC_SSPXR_Switcher_ModuleLifeSupportRecycler_StopActionName // #LOC_SSPXR_Switcher_ModuleLifeSupportRecycler_StopActionName = Stop Life Support
-
-		CrewCapacity = 4
-		RecyclePercent = 0.5
-
-		INPUT_RESOURCE
-		{
-			ResourceName = ElectricCharge
-			Ratio = 1.5
-		}
-	}
-}
+//Science Labs
+//PMA-4 'Nature' Science Lab
 //PXL-2 'Fate' Deep-Space Laboratory Module
-@PART[sspx-lab-375-1]:NEEDS[USILifeSupport]
+//SDV-6 'Delphi' Science Module
+@PART[sspx-science-1875-1|sspx-lab-375-1|sspx-lab-5-1]:NEEDS[USILifeSupport]
 {
 	MODULE
 	{
@@ -646,422 +1155,114 @@
 		StartActionName = #LOC_SSPXR_Switcher_ModuleLifeSupportRecycler_StartActionName // #LOC_SSPXR_Switcher_ModuleLifeSupportRecycler_StartActionName = Start Life Support
 		StopActionName = #LOC_SSPXR_Switcher_ModuleLifeSupportRecycler_StopActionName // #LOC_SSPXR_Switcher_ModuleLifeSupportRecycler_StopActionName = Stop Life Support
 
-		CrewCapacity = 6
+		CrewCapacity = #$/CrewCapacity$
+		@CrewCapacity *= 2
 		RecyclePercent = 0.5
 
 		INPUT_RESOURCE
 		{
 			ResourceName = ElectricCharge
 			Ratio = 1.5
-		}
-	}
-}
-//PXL-F15H Aquaculture Module
-@PART[sspx-aquaculture-375-1]:NEEDS[USILifeSupport]
-{
-	MODULE
-	{
-		name = USI_SwapController
-	}
-	MODULE
-	{
-		name = USI_SwappableBay
-		bayName = Bay 1
-		moduleIndex = 0
-	}
-	MODULE
-	{
-		name = USI_Converter
-		UseSpecialistBonus = false
-	}
-	MODULE
-	{
-		name = USILS_LifeSupportRecyclerSwapOption
-		ConverterName = #LOC_SSPXR_Switcher_ModuleLifeSupportRecycler_ConverterName // #LOC_SSPXR_Switcher_ModuleLifeSupportRecycler_ConverterName = Life Support
-		StartActionName = #LOC_SSPXR_Switcher_ModuleLifeSupportRecycler_StartActionName // #LOC_SSPXR_Switcher_ModuleLifeSupportRecycler_StartActionName = Start Life Support
-		StopActionName = #LOC_SSPXR_Switcher_ModuleLifeSupportRecycler_StopActionName // #LOC_SSPXR_Switcher_ModuleLifeSupportRecycler_StopActionName = Stop Life Support
-
-		CrewCapacity = 4
-		RecyclePercent = 0.81
-
-		INPUT_RESOURCE
-		{
-			ResourceName = ElectricCharge
-			Ratio = 36.25
-		}
-	}
-}
-//INFLATABLES
-//PTD-E-2 'Eclair' Inflatable Habitation Module
-@PART[sspx-inflatable-hab-125-1]:NEEDS[USILifeSupport]
-
-{	MODULE
-	{
-		name = USI_SwapController
-	}
-	MODULE
-	{
-		name = USI_SwappableBay
-		bayName = Bay 1
-		moduleIndex = 0
-	}
-
-	MODULE
-	{
-		name = USI_Converter
-		UseSpecialistBonus = false
-	}
-	MODULE 
-	{
-		name = USILS_HabitationSwapOption
-		ConverterName = #LOC_SSPXR_Switcher_ModuleHabitation_ConverterName // #LOC_SSPXR_Switcher_ModuleHabitation_ConverterName = Habitat
-		StartActionName = #LOC_SSPXR_Switcher_ModuleHabitation_StartActionName // #LOC_SSPXR_Switcher_ModuleHabitation_StartActionName = Start Habitat
-		StopActionName = #LOC_SSPXR_Switcher_ModuleHabitation_StopActionName // #LOC_SSPXR_Switcher_ModuleHabitation_StopActionName = Stop Habitat		
-
-		BaseKerbalMonths = 19
-		CrewCapacity = #$../MODULE[ModuleDeployableHabitat]/DeployedCrewCapacity$
-		BaseHabMultiplier = 0.6
-
-		INPUT_RESOURCE
-		{
-			ResourceName = ElectricCharge
-			Ratio = 1.55
-		}
-	}
-}
-
-//PTD-E-1A 'Winston' Inflatable Habitation Module
-@PART[sspx-inflatable-hab-125-2]:NEEDS[USILifeSupport]
-{
-	MODULE
-	{
-		name = USI_SwapController
-	}
-	MODULE
-	{
-		name = USI_SwappableBay
-		bayName = Bay 1
-		moduleIndex = 0
-	}
-
-	MODULE
-	{
-		name = USI_Converter
-		UseSpecialistBonus = false
-	}
-	MODULE 
-	{
-		name = USILS_HabitationSwapOption
-		ConverterName = #LOC_SSPXR_Switcher_ModuleHabitation_ConverterName // #LOC_SSPXR_Switcher_ModuleHabitation_ConverterName = Habitat
-		StartActionName = #LOC_SSPXR_Switcher_ModuleHabitation_StartActionName // #LOC_SSPXR_Switcher_ModuleHabitation_StartActionName = Start Habitat
-		StopActionName = #LOC_SSPXR_Switcher_ModuleHabitation_StopActionName // #LOC_SSPXR_Switcher_ModuleHabitation_StopActionName = Stop Habitat		
-
-		BaseKerbalMonths = 7
-		CrewCapacity = #$../MODULE[ModuleDeployableHabitat]/DeployedCrewCapacity$
-		BaseHabMultiplier = 0.3
-
-		INPUT_RESOURCE
-		{
-			ResourceName = ElectricCharge
-			Ratio = 0.65
-		}
-	}
-}
-//PTD-E-1B 'Winston' Inflatable Habitation Module
-@PART[sspx-inflatable-hab-125-3]:NEEDS[USILifeSupport]
-{
-	MODULE
-	{
-		name = USI_SwapController
-	}
-	MODULE
-	{
-		name = USI_SwappableBay
-		bayName = Bay 1
-		moduleIndex = 0
-	}
-
-	MODULE
-	{
-		name = USI_Converter
-		UseSpecialistBonus = false
-	}
-	MODULE 
-	{
-		name = USILS_HabitationSwapOption
-		ConverterName = #LOC_SSPXR_Switcher_ModuleHabitation_ConverterName // #LOC_SSPXR_Switcher_ModuleHabitation_ConverterName = Habitat
-		StartActionName = #LOC_SSPXR_Switcher_ModuleHabitation_StartActionName // #LOC_SSPXR_Switcher_ModuleHabitation_StartActionName = Start Habitat
-		StopActionName = #LOC_SSPXR_Switcher_ModuleHabitation_StopActionName // #LOC_SSPXR_Switcher_ModuleHabitation_StopActionName = Stop Habitat		
-
-		BaseKerbalMonths = 7
-		CrewCapacity = #$../MODULE[ModuleDeployableHabitat]/DeployedCrewCapacity$
-		BaseHabMultiplier = 0.3
-
-		INPUT_RESOURCE
-		{
-			ResourceName = ElectricCharge
-			Ratio = 0.65
-		}
-	}
-}
-
-//PFD-A Inflatable Habitation Module
-@PART[sspx-inflatable-hab-25-1]:NEEDS[USILifeSupport]
-{
-	MODULE
-	{
-		name = USI_SwapController
-	}
-	MODULE
-	{
-		name = USI_SwappableBay
-		bayName = Bay 1
-		moduleIndex = 0
-	}
-	MODULE
-	{
-		name = USI_Converter
-		UseSpecialistBonus = false
-	}
-	MODULE 
-	{
-		name = USILS_HabitationSwapOption
-		ConverterName = #LOC_SSPXR_Switcher_ModuleHabitation_ConverterName // #LOC_SSPXR_Switcher_ModuleHabitation_ConverterName = Habitat
-		StartActionName = #LOC_SSPXR_Switcher_ModuleHabitation_StartActionName // #LOC_SSPXR_Switcher_ModuleHabitation_StartActionName = Start Habitat
-		StopActionName = #LOC_SSPXR_Switcher_ModuleHabitation_StopActionName // #LOC_SSPXR_Switcher_ModuleHabitation_StopActionName = Stop Habitat	
-
-		BaseKerbalMonths = 209
-		CrewCapacity = #$../MODULE[ModuleDeployableHabitat]/DeployedCrewCapacity$
-		BaseHabMultiplier = 2
-
-		INPUT_RESOURCE
-		{
-			ResourceName = ElectricCharge
-			Ratio = 12.45
-		}
-	}
-}
-//PFD-B Inflatable Habitation Module
-@PART[sspx-inflatable-hab-25-2]:NEEDS[USILifeSupport]
-{
-	MODULE
-	{
-		name = USI_SwapController
-	}
-	MODULE
-	{
-		name = USI_SwappableBay
-		bayName = Bay 1
-		moduleIndex = 0
-	}
-	MODULE
-	{
-
-		name = USI_Converter
-		UseSpecialistBonus = false
-	}
-	MODULE 
-	{
-		name = USILS_HabitationSwapOption
-		ConverterName = #LOC_SSPXR_Switcher_ModuleHabitation_ConverterName // #LOC_SSPXR_Switcher_ModuleHabitation_ConverterName = Habitat
-		StartActionName = #LOC_SSPXR_Switcher_ModuleHabitation_StartActionName // #LOC_SSPXR_Switcher_ModuleHabitation_StartActionName = Start Habitat
-		StopActionName = #LOC_SSPXR_Switcher_ModuleHabitation_StopActionName // #LOC_SSPXR_Switcher_ModuleHabitation_StopActionName = Stop Habitat	
-
-		BaseKerbalMonths = 93
-		CrewCapacity = #$../MODULE[ModuleDeployableHabitat]/DeployedCrewCapacity$
-		BaseHabMultiplier = 1
-
-		INPUT_RESOURCE
-		{
-			ResourceName = ElectricCharge
-			Ratio = 5.65
-		}
-	}
-}
-//CENTRIFUGES
-//CTD-10 Inflatable Centrifuge Module
-@PART[sspx-inflatable-centrifuge-125-1]:NEEDS[USILifeSupport]
-{
-	MODULE
-	{
-		name = USI_SwapController
-	}
-	MODULE
-	{
-		name = USI_SwappableBay
-		bayName = Bay 1
-		moduleIndex = 0
-	}
-	MODULE
-	{
-		name = USI_Converter
-		UseSpecialistBonus = false
-	}
-	MODULE 
-	{
-		name = USILS_HabitationSwapOption
-		ConverterName = #LOC_SSPXR_Switcher_ModuleHabitation_ConverterName // #LOC_SSPXR_Switcher_ModuleHabitation_ConverterName = Habitat
-		StartActionName = #LOC_SSPXR_Switcher_ModuleHabitation_StartActionName // #LOC_SSPXR_Switcher_ModuleHabitation_StartActionName = Start Habitat
-		StopActionName = #LOC_SSPXR_Switcher_ModuleHabitation_StopActionName // #LOC_SSPXR_Switcher_ModuleHabitation_StopActionName = Stop Habitat	
-
-		BaseKerbalMonths = 30
-		CrewCapacity = #$../MODULE[ModuleDeployableCentrifuge]/DeployedCrewCapacity$
-		BaseHabMultiplier = 1.2
-
-		INPUT_RESOURCE
-		{
-			ResourceName = ElectricCharge
-			Ratio = 8.5375
-		}
-	}
-}
-//CTD-5 Compact Inflatable Centrifuge Module
-@PART[sspx-inflatable-centrifuge-125-2]:NEEDS[USILifeSupport]
-{
-	MODULE
-	{
-		name = USI_SwapController
-	}
-	MODULE
-	{
-		name = USI_SwappableBay
-		bayName = Bay 1
-		moduleIndex = 0
-	}
-	MODULE
-	{
-		name = USI_Converter
-		UseSpecialistBonus = false
-	}
-	MODULE 
-	{
-		name = USILS_HabitationSwapOption
-		ConverterName = #LOC_SSPXR_Switcher_ModuleHabitation_ConverterName // #LOC_SSPXR_Switcher_ModuleHabitation_ConverterName = Habitat
-		StartActionName = #LOC_SSPXR_Switcher_ModuleHabitation_StartActionName // #LOC_SSPXR_Switcher_ModuleHabitation_StartActionName = Start Habitat
-		StopActionName = #LOC_SSPXR_Switcher_ModuleHabitation_StopActionName // #LOC_SSPXR_Switcher_ModuleHabitation_StopActionName = Stop Habitat		
-		BaseKerbalMonths = 10
-		CrewCapacity = #$../MODULE[ModuleDeployableCentrifuge]/DeployedCrewCapacity$
-		BaseHabMultiplier = 0.6
-
-		INPUT_RESOURCE
-		{
-			ResourceName = ElectricCharge
-			Ratio = 2.65
-		}
-	}
-}
-//PFD-C Inflatable Centrifuge Module
-@PART[sspx-inflatable-centrifuge-25-1]:NEEDS[USILifeSupport]
-
-{
-	MODULE
-	{
-		name = USI_SwapController
-	}
-	MODULE
-	{
-		name = USI_SwappableBay
-		bayName = Bay 1
-		moduleIndex = 0
-	}
-	MODULE
-	{
-		name = USI_Converter
-		UseSpecialistBonus = false
-	}
-	MODULE 
-	{
-		name = USILS_HabitationSwapOption
-		ConverterName = #LOC_SSPXR_Switcher_ModuleHabitation_ConverterName // #LOC_SSPXR_Switcher_ModuleHabitation_ConverterName = Habitat
-		StartActionName = #LOC_SSPXR_Switcher_ModuleHabitation_StartActionName // #LOC_SSPXR_Switcher_ModuleHabitation_StartActionName = Start Habitat
-		StopActionName = #LOC_SSPXR_Switcher_ModuleHabitation_StopActionName // #LOC_SSPXR_Switcher_ModuleHabitation_StopActionName = Stop Habitat	
-
-		BaseKerbalMonths = 121
-		CrewCapacity = #$../MODULE[ModuleDeployableCentrifuge]/DeployedCrewCapacity$
-		BaseHabMultiplier = 1.6
-
-		INPUT_RESOURCE
-		{
-			ResourceName = ElectricCharge
-			Ratio = 23.825
-		}
-	}
-}
-//PXL-E 'Mercury' Extensible Centrifuge
-@PART[sspx-expandable-centrifuge-375-1]:NEEDS[USILifeSupport]
-{
-	MODULE
-	{
-		name = USI_SwapController
-	}
-	MODULE
-	{
-		name = USI_SwappableBay
-		bayName = Bay 1
-		moduleIndex = 0
-	}
-	MODULE
-	{
-		name = USI_Converter
-		UseSpecialistBonus = false
-	}
-	MODULE 
-	{
-		name = USILS_HabitationSwapOption
-		ConverterName = #LOC_SSPXR_Switcher_ModuleHabitation_ConverterName // #LOC_SSPXR_Switcher_ModuleHabitation_ConverterName = Habitat
-		StartActionName = #LOC_SSPXR_Switcher_ModuleHabitation_StartActionName // #LOC_SSPXR_Switcher_ModuleHabitation_StartActionName = Start Habitat
-		StopActionName = #LOC_SSPXR_Switcher_ModuleHabitation_StopActionName // #LOC_SSPXR_Switcher_ModuleHabitation_StopActionName = Stop Habitat		
-
-		BaseKerbalMonths = 288
-		CrewCapacity = #$../MODULE[ModuleDeployableCentrifuge]/DeployedCrewCapacity$
-		BaseHabMultiplier = 3.9
-
-		INPUT_RESOURCE
-		{
-			ResourceName = ElectricCharge
-			Ratio = 56.4
-		}
-	}
-}
-//PXL-F 'Pilgrim' Extensible Centrifuge
-@PART[sspx-expandable-centrifuge-375-2]:NEEDS[USILifeSupport]
-{
-	MODULE
-	{
-		name = USI_SwapController
-	}
-	MODULE
-	{
-		name = USI_SwappableBay
-		bayName = Bay 1
-		moduleIndex = 0
-	}
-	MODULE
-	{
-		name = USI_Converter
-		UseSpecialistBonus = false
-	}
-	MODULE 
-	{
-		name = USILS_HabitationSwapOption
-		ConverterName = #LOC_SSPXR_Switcher_ModuleHabitation_ConverterName // #LOC_SSPXR_Switcher_ModuleHabitation_ConverterName = Habitat
-		StartActionName = #LOC_SSPXR_Switcher_ModuleHabitation_StartActionName // #LOC_SSPXR_Switcher_ModuleHabitation_StartActionName = Start Habitat
-		StopActionName = #LOC_SSPXR_Switcher_ModuleHabitation_StopActionName // #LOC_SSPXR_Switcher_ModuleHabitation_StopActionName = Stop Habitat		
-
-		BaseKerbalMonths = 108
-		CrewCapacity = #$../MODULE[ModuleDeployableCentrifuge]/DeployedCrewCapacity$
-		BaseHabMultiplier = 2.8
-
-		INPUT_RESOURCE
-		{
-			ResourceName = ElectricCharge
-			Ratio = 15.35
 		}
 	}
 }
 //Greenhouses
+//PAS-G 'G4RD3N' Hydroponics Cupola
+//too small for a "bay", using custom values
+@PART[sspx-cupola-greenhouse-125-1]:NEEDS[USILifeSupport]
+{
+	RESOURCE
+	{
+		name = Mulch
+		amount = 0
+		maxAmount = 100
+	}
+	RESOURCE
+	{
+		name = Supplies
+		amount = 0
+		maxAmount = 100
+	}
+	RESOURCE
+	{
+		name = Fertilizer
+		amount = 0
+		maxAmount = 100
+	}
+	RESOURCE
+	{
+		name = ElectricCharge
+		amount = 600
+		maxAmount = 200
+	}
+	MODULE
+	{
+		name = USI_SwapController
+	}
+	MODULE
+	{
+		name = USI_SwappableBay
+		bayName = Bay 1
+		moduleIndex = 0
+	}
+	MODULE
+	{
+		name = USI_Converter
+		UseSpecialistBonus = false
+	}
+	MODULE
+	{
+		name = USI_ConverterSwapOption
+		ConverterName = #LOC_SSPXR_Switcher_ModuleResourceConverter_USI_ConverterName // #LOC_SSPXR_Switcher_ModuleResourceConverter_USI_ConverterName = Agroponics
+		StartActionName = #LOC_SSPXR_Switcher_ModuleResourceConverter_USI_StartActionName // #LOC_SSPXR_Switcher_ModuleResourceConverter_USI_StartActionName = Start Agroponics
+		StopActionName = #LOC_SSPXR_Switcher_ModuleResourceConverter_USI_StopActionName // #LOC_SSPXR_Switcher_ModuleResourceConverter_USI_StopActionName = Stop Agroponics
+
+		INPUT_RESOURCE
+		{
+			ResourceName = Mulch
+			Ratio =  0.00050000
+		}
+		INPUT_RESOURCE
+		{
+			ResourceName = Fertilizer
+			Ratio =  0.00005000
+		}
+		OUTPUT_RESOURCE
+		{
+			ResourceName = Supplies
+			Ratio = 0.00055000
+			DumpExcess = False
+		}
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 1.10
+		}
+	}
+	MODULE
+	
+	{
+		name = USILS_LifeSupportRecyclerSwapOption
+		ConverterName = HV Recycler
+		StartActionName = Start HV Recycler
+		StopActionName = Stop HV Recycler
+
+		CrewCapacity = 5
+		RecyclePercent = 0.6
+
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 2.5
+		}
+	}
+}
 //PPD-F412M Hydroponics Module
-@PART[sspx-greenhouse-25-1]:NEEDS[USILifeSupport]
+//PXL-F15H Aquaculture Module
+//PXL-R4NCH-3R Hydroponics Module
+//SDV-4 'Demeter' Cultivation Module
+//SDV-G2 'Villa' Cultivation Dome
+@PART[sspx-greenhouse-25-1|sspx-aquaculture-375-1|sspx-greenhouse-375-1|sspx-greenhouse-5-1|sspx-dome-greenhouse-5-1]:NEEDS[USILifeSupport]
 {
 	RESOURCE
 	{
@@ -1104,87 +1305,9 @@
 	}
 	MODULE
 	{
-		name = USI_ConverterSwapOption
-		ConverterName = #LOC_SSPXR_Switcher_ModuleResourceConverter_USI_ConverterName // #LOC_SSPXR_Switcher_ModuleResourceConverter_USI_ConverterName = Agroponics
-		StartActionName = #LOC_SSPXR_Switcher_ModuleResourceConverter_USI_StartActionName // #LOC_SSPXR_Switcher_ModuleResourceConverter_USI_StartActionName = Start Agroponics
-		StopActionName = #LOC_SSPXR_Switcher_ModuleResourceConverter_USI_StopActionName // #LOC_SSPXR_Switcher_ModuleResourceConverter_USI_StopActionName = Stop Agroponics
-
-		INPUT_RESOURCE
-		{
-			ResourceName = Mulch
-			Ratio =  0.00150000
-		}
-		INPUT_RESOURCE
-		{
-			ResourceName = Fertilizer
-			Ratio =  0.00015000
-		}
-		OUTPUT_RESOURCE
-		{
-			ResourceName = Supplies
-			Ratio = 0.00165000
-			DumpExcess = False
-		}
-		INPUT_RESOURCE
-		{
-			ResourceName = ElectricCharge
-			Ratio = 3.30
-		}
-	}
-	MODULE
-	
-	{
-		name = USILS_LifeSupportRecyclerSwapOption
-		ConverterName = #LOC_SSPXR_Switcher_ModuleLifeSupportRecycler_ConverterName // #LOC_SSPXR_Switcher_ModuleLifeSupportRecycler_ConverterName = Life Support
-		StartActionName = #LOC_SSPXR_Switcher_ModuleLifeSupportRecycler_StartActionName // #LOC_SSPXR_Switcher_ModuleLifeSupportRecycler_StartActionName = Start Life Support
-		StopActionName = #LOC_SSPXR_Switcher_ModuleLifeSupportRecycler_StopActionName // #LOC_SSPXR_Switcher_ModuleLifeSupportRecycler_StopActionName = Stop Life Support
-
-		CrewCapacity = 2
-		RecyclePercent = 0.7
-
-		INPUT_RESOURCE
-		{
-			ResourceName = ElectricCharge
-			Ratio = 3.5
-		}
-	}
-}
-//PXL-R4NCH-3R Hydroponics Module
-@PART[sspx-greenhouse-375-1]:NEEDS[USILifeSupport]
-{
-	RESOURCE
-	{
-		name = Mulch
-		amount = 0
-		maxAmount = 500
-	}
-	RESOURCE
-	{
-		name = Supplies
-		amount = 0
-		maxAmount = 500
-	}
-	RESOURCE
-	{
-		name = Fertilizer
-		amount = 0
-		maxAmount = 500
-	}
-	RESOURCE
-	{
-		name = ElectricCharge
-		amount = 1000
-		maxAmount = 1000
-	}
-	MODULE
-	{
-		name = USI_SwapController
-	}
-	MODULE
-	{
 		name = USI_SwappableBay
-		bayName = Bay 1
-		moduleIndex = 0
+		bayName = Bay 2
+		moduleIndex = 1
 	}
 	MODULE
 	{
@@ -1201,39 +1324,157 @@
 		INPUT_RESOURCE
 		{
 			ResourceName = Mulch
-			Ratio =  0.00250000
+			Ratio =  0.0020000
 		}
 		INPUT_RESOURCE
 		{
 			ResourceName = Fertilizer
-			Ratio =  0.00025000
+			Ratio =  0.00020000
 		}
 		OUTPUT_RESOURCE
 		{
 			ResourceName = Supplies
-			Ratio = 0.00275000
+			Ratio = 0.00220000
 			DumpExcess = False
 		}
 		INPUT_RESOURCE
 		{
 			ResourceName = ElectricCharge
-			Ratio = 5.25
+			Ratio = 3.30
 		}
 	}
 	MODULE
 	{
 		name = USILS_LifeSupportRecyclerSwapOption
-		ConverterName = #LOC_SSPXR_Switcher_ModuleLifeSupportRecycler_ConverterName // #LOC_SSPXR_Switcher_ModuleLifeSupportRecycler_ConverterName = Life Support
-		StartActionName = #LOC_SSPXR_Switcher_ModuleLifeSupportRecycler_StartActionName // #LOC_SSPXR_Switcher_ModuleLifeSupportRecycler_StartActionName = Start Life Support
-		StopActionName = #LOC_SSPXR_Switcher_ModuleLifeSupportRecycler_StopActionName // #LOC_SSPXR_Switcher_ModuleLifeSupportRecycler_StopActionName = Stop Life Support
+		ConverterName = HV Recycler
+		StartActionName = Start HV Recycler
+		StopActionName = Stop HV Recycler
 
-		CrewCapacity = 3
-		RecyclePercent = 0.7
+		CrewCapacity = 20
+		RecyclePercent = 0.6
 
 		INPUT_RESOURCE
 		{
 			ResourceName = ElectricCharge
-			Ratio = 5.25
+			Ratio = 10
 		}
+	}
+	MODULE
+	{
+		name = USILS_LifeSupportRecyclerSwapOption
+		ConverterName = HE Recycler
+		StartActionName = Start HE Recycler
+		StopActionName = Stop HE Recycler
+
+		CrewCapacity = 1
+		RecyclePercent = 0.81
+
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 35
+		}
+	}
+}
+@PART[sspx-aquaculture-375-1]:NEEDS[USILifeSupport]
+{
+	MODULE
+	{
+		name = USILS_HabitationSwapOption
+		ConverterName = Hab-Common
+		StartActionName = Start Hab-Common
+		StopActionName = Stop Hab-Common
+
+		BaseKerbalMonths = 6
+		CrewCapacity = 6
+		BaseHabMultiplier = 1
+
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 0.44
+		}
+	}
+}
+@PART[sspx-aquaculture-375-1|sspx-greenhouse-375-1]:NEEDS[USILifeSupport]
+{
+	@RESOURCE[Mulch]
+	{
+		@maxAmount = 500
+	}
+	@RESOURCE[Supplies]
+	{
+		@maxAmount = 500
+	}
+	@RESOURCE[Fertilizer]
+	{
+		@maxAmount = 500
+	}
+	@RESOURCE[ElectricCharge]
+	{
+		@amount = 1000
+		@maxAmount = 1000
+	}
+}
+@PART[sspx-greenhouse-5-1|sspx-dome-greenhouse-5-1]:NEEDS[USILifeSupport]
+{
+	@RESOURCE[Mulch]
+	{
+		@maxAmount = 1500
+	}
+	@RESOURCE[Supplies]
+	{
+		@maxAmount = 1500
+	}
+	@RESOURCE[Fertilizer]
+	{
+		@maxAmount = 1500
+	}
+	@RESOURCE[ElectricCharge]
+	{
+		@amount = 3000
+		@maxAmount = 3000
+	}
+}
+@PART[sspx-aquaculture-375-1|sspx-greenhouse-375-1|sspx-greenhouse-5-1|sspx-dome-greenhouse-5-1]:NEEDS[USILifeSupport]
+{
+	MODULE
+	{
+		name = USI_SwappableBay
+		bayName = Bay 3
+		moduleIndex = 2
+	}
+	MODULE
+	{
+		name = USI_Converter
+		UseSpecialistBonus = false
+	}
+}
+@PART[sspx-aquaculture-375-1|sspx-greenhouse-5-1]:NEEDS[USILifeSupport]
+{
+	MODULE
+	{
+		name = USI_SwappableBay
+		bayName = Bay 4
+		moduleIndex = 3
+	}
+	MODULE
+	{
+		name = USI_Converter
+		UseSpecialistBonus = false
+	}
+}
+@PART[sspx-greenhouse-5-1]:NEEDS[USILifeSupport]
+{
+	MODULE
+	{
+		name = USI_SwappableBay
+		bayName = Bay 5
+		moduleIndex = 4
+	}
+	MODULE
+	{
+		name = USI_Converter
+		UseSpecialistBonus = false
 	}
 }


### PR DESCRIPTION
This proposal gives SSPX a niche in the USI-LS ecosystem by focusing on heavy, configurable parts to aid in reducing part count while remaining balanced per ton on large space stations and bases.  When MKS is not installed, the masses are not modified, making the habitation somewhat overpowered, but remaining in the spirit of the previous version of this patch.