### PR TITLE
Misspelling fix

### DIFF
--- a/GameData/StationPartsExpansionRedux/Patches/SSPXR-Contracts.cfg
+++ b/GameData/StationPartsExpansionRedux/Patches/SSPXR-Contracts.cfg
@@ -33,7 +33,7 @@
 	{
 		@PART_REQUEST:HAS[#Part[Large.Crewed.Lab]]
 		{
-      Part = sspx-lab-1875-1
+      Part = sspx-science-1875-1
 			Part = sspx-lab-375-1
       Part = sspx-lab-5-1
       Part = sspx-expandable-centrifuge-5-1
@@ -43,7 +43,7 @@
 	{
 		@PART_REQUEST:HAS[#Part[Large.Crewed.Lab]]
 		{
-      Part = sspx-lab-1875-1
+      Part = sspx-science-1875-1
 			Part = sspx-lab-375-1
       Part = sspx-lab-5-1
       Part = sspx-expandable-centrifuge-5-1


### PR DESCRIPTION
Unlike other science labs (except for the centrifuge), the 1.875 meter lab has "science" insted of "lab".
I'm not sure why it's in the patch-1 branch and not the dev branch but oh well, I'm not a GitHub pro.