### PR TITLE
Fix 5m endcaps

### DIFF
--- a/GameData/StationPartsExpansionRedux/Parts/Extendable/extendable-5/sspx-expandable-centrifuge-5-1.cfg
+++ b/GameData/StationPartsExpansionRedux/Parts/Extendable/extendable-5/sspx-expandable-centrifuge-5-1.cfg
@@ -12,21 +12,21 @@ PART
 	rescaleFactor = 1
 
 	// --- node definitions ---
-	node_stack_top = 0.0,  3.994, 0.0, 0.0, 1.0, 0.0, 4
-	node_stack_bottom = 0.0,  -11.593, 0.0, 0.0, -1.0, 0.0, 4
+	node_stack_top = 0.0,  3.99823, 0.0, 0.0, 1.0, 0.0, 4
+	node_stack_bottom = 0.0,  -11.5983, 0.0, 0.0, -1.0, 0.0, 4
 
 
 	MODEL
 	{
 		model = StationPartsExpansionRedux/Parts/Common/sspx-endcap-5-solid-1-mirrored
-		position = 0.0, -11.593, 0.0
+		position = 0.0, -11.5983, 0.0
 		scale = 1,1,1 
 		rotation = 0, 0, 0
 	}
 	MODEL
 	{
 		model = StationPartsExpansionRedux/Parts/Common/sspx-endcap-5-solid-1
-		position = 0.0,  3.994, 0.0
+		position = 0.0,  3.99823, 0.0
 		scale = 1,1,1
 		rotation = 0, 0, 0
 	}

--- a/GameData/StationPartsExpansionRedux/Parts/Rigid/station-5/sspx-adapter-375-5-1.cfg
+++ b/GameData/StationPartsExpansionRedux/Parts/Rigid/station-5/sspx-adapter-375-5-1.cfg
@@ -25,7 +25,7 @@ PART
 	MODEL
   {
     model = StationPartsExpansionRedux/Parts/Common/sspx-endcap-5-solid-1-mirrored
-    position = 0.0,  -0.9490356, 0.0
+    position = 0.0,  -0.943727, 0.0
     scale = 1,1,1
     rotation = 0, 0, 0
   }
@@ -34,7 +34,7 @@ PART
 
 	// --- node definitions ---
 	node_stack_top = 0.0, 0.987394, 0.0, 0.0, 1.0, 0.0, 3
-	node_stack_bottom = 0.0, -0.9490356, 0.0, 0.0, -1.0, 0.0, 4
+	node_stack_bottom = 0.0, -0.943727, 0.0, 0.0, -1.0, 0.0, 4
 
 
 	// --- editor parameters ---

--- a/GameData/StationPartsExpansionRedux/Parts/Rigid/station-5/sspx-adapter-375-5-2.cfg
+++ b/GameData/StationPartsExpansionRedux/Parts/Rigid/station-5/sspx-adapter-375-5-2.cfg
@@ -25,7 +25,7 @@ PART
   MODEL
   {
     model = StationPartsExpansionRedux/Parts/Common/sspx-endcap-5-solid-1-mirrored
-    position = 0.0,  -0.3551125, 0.0
+    position = 0.0,  -0.355608, 0.0
     scale = 1,1,1
     rotation = 0, 0, 0
   }
@@ -34,7 +34,7 @@ PART
 
   // --- node definitions ---
   node_stack_top = 0.0, 0.1379868, 0.0, 0.0, 1.0, 0.0, 3
-  node_stack_bottom = 0.0, -0.3551125, 0.0, 0.0, -1.0, 0.0, 4
+  node_stack_bottom = 0.0, -0.355608, 0.0, 0.0, -1.0, 0.0, 4
 
 	// --- editor parameters ---
 	TechRequired = nanolathing

--- a/GameData/StationPartsExpansionRedux/Parts/Rigid/station-5/sspx-core-5-1.cfg
+++ b/GameData/StationPartsExpansionRedux/Parts/Rigid/station-5/sspx-core-5-1.cfg
@@ -18,14 +18,14 @@ PART
 	MODEL
 	{
 		model = StationPartsExpansionRedux/Parts/Common/sspx-endcap-5-solid-1-mirrored
-		position = 0.0,  -1.319406, 0.0
+		position = 0.0,  -1.31725, 0.0
 		scale = 1,1,1
 		rotation = 0, 0, 0
 	}
 	MODEL
 	{
 		model = StationPartsExpansionRedux/Parts/Common/sspx-endcap-5-solid-1
-		position = 0.0, 1.33576, 0.0
+		position = 0.0, 1.33381, 0.0
 		scale = 1,1,1
 		rotation = 0, 0, 0
 	}
@@ -33,8 +33,8 @@ PART
 	rescaleFactor = 1
 
 	// --- node definitions ---
-	node_stack_top = 0.0, 1.33576, 0.0, 0.0, 1.0, 0.0, 4
-	node_stack_bottom = 0.0, -1.319406, 0.0, 0.0, -1.0, 0.0, 4
+	node_stack_top = 0.0, 1.33381, 0.0, 0.0, 1.0, 0.0, 4
+	node_stack_bottom = 0.0, -1.31725, 0.0, 0.0, -1.0, 0.0, 4
 
 
 	// --- editor parameters ---

--- a/GameData/StationPartsExpansionRedux/Parts/Rigid/station-5/sspx-dome-5-1.cfg
+++ b/GameData/StationPartsExpansionRedux/Parts/Rigid/station-5/sspx-dome-5-1.cfg
@@ -18,7 +18,7 @@ PART
 	MODEL
 	{
 		model = StationPartsExpansionRedux/Parts/Common/sspx-endcap-5-solid-1
-		position = 0.0,  -1.086, 0.0
+		position = 0.0,  -1.08037, 0.0
 		scale = 1,-1,1
 		rotation = 0, 0, 0
 	}
@@ -28,12 +28,12 @@ PART
 
 	// --- node definitions ---
 	
-	node_stack_bottom = 0.0, -1.086, 0.0, 0.0, -1.0, 0.0, 4
+	node_stack_bottom = 0.0, -1.08037, 0.0, 0.0, -1.0, 0.0, 4
   node_stack_south =  0, -0.29, -2.54, 0.0, 0.0, -1.0, 1
   node_stack_north =  0, -0.29, 2.54, 0.0, 0.0, 1.0, 1
   node_stack_west =  -2.54, -0.29, 0.0, -1.0, 0.0, 0.0, 1
   node_stack_east =  2.54, -0.29, 0.0, 1.0, 0.0, 0.0, 1
-  node_attach =  0.0, -1.086, 0.0, 0.0, -1.0, 0.0, 4
+  node_attach =  0.0, -1.08037, 0.0, 0.0, -1.0, 0.0, 4
 
 	// --- editor parameters ---
 	TechRequired = advScienceTech

--- a/GameData/StationPartsExpansionRedux/Parts/Rigid/station-5/sspx-dome-cupola-5-1.cfg
+++ b/GameData/StationPartsExpansionRedux/Parts/Rigid/station-5/sspx-dome-cupola-5-1.cfg
@@ -18,7 +18,7 @@ PART
 	MODEL
 	{
 		model = StationPartsExpansionRedux/Parts/Common/sspx-endcap-5-solid-1
-		position = 0.0,  -1.086, 0.0
+		position = 0.0,  -1.08037, 0.0
 		scale = 1,-1,1
 		rotation = 0, 0, 0
 	}
@@ -28,12 +28,12 @@ PART
 
 	// --- node definitions ---
 	
-	node_stack_bottom = 0.0, -1.086, 0.0, 0.0, -1.0, 0.0, 4
+	node_stack_bottom = 0.0, -1.08037, 0.0, 0.0, -1.0, 0.0, 4
   node_stack_south =  0, -0.29, -2.54, 0.0, 0.0, -1.0, 1
   node_stack_north =  0, -0.29, 2.54, 0.0, 0.0, 1.0, 1
   node_stack_west =  -2.54, -0.29, 0.0, -1.0, 0.0, 0.0, 1
   node_stack_east =  2.54, -0.29, 0.0, 1.0, 0.0, 0.0, 1
-  node_attach =  0.0, -1.086, 0.0, 0.0, -1.0, 0.0, 4
+  node_attach =  0.0, -1.08037, 0.0, 0.0, -1.0, 0.0, 4
 
 	// --- editor parameters ---
 	TechRequired = advScienceTech
@@ -347,5 +347,4 @@ MODULE
     }
  
   }
-	
 }

--- a/GameData/StationPartsExpansionRedux/Parts/Rigid/station-5/sspx-dome-greenhouse-5-1.cfg
+++ b/GameData/StationPartsExpansionRedux/Parts/Rigid/station-5/sspx-dome-greenhouse-5-1.cfg
@@ -18,7 +18,7 @@ PART
 	MODEL
 	{
 		model = StationPartsExpansionRedux/Parts/Common/sspx-endcap-5-solid-1
-		position = 0.0,  -1.086, 0.0
+		position = 0.0,  -1.08037, 0.0
 		scale = 1,-1,1
 		rotation = 0, 0, 0
 	}
@@ -28,12 +28,12 @@ PART
 
 	// --- node definitions ---
 	
-	node_stack_bottom = 0.0, -1.086, 0.0, 0.0, -1.0, 0.0, 4
+	node_stack_bottom = 0.0, -1.08037, 0.0, 0.0, -1.0, 0.0, 4
   node_stack_south =  0, -0.29, -2.54, 0.0, 0.0, -1.0, 1
   node_stack_north =  0, -0.29, 2.54, 0.0, 0.0, 1.0, 1
   node_stack_west =  -2.54, -0.29, 0.0, -1.0, 0.0, 0.0, 1
   node_stack_east =  2.54, -0.29, 0.0, 1.0, 0.0, 0.0, 1
-  node_attach =  0.0, -1.086, 0.0, 0.0, -1.0, 0.0, 4
+  node_attach =  0.0, -1.08037, 0.0, 0.0, -1.0, 0.0, 4
 
 	// --- editor parameters ---
 	TechRequired = advScienceTech

--- a/GameData/StationPartsExpansionRedux/Parts/Rigid/station-5/sspx-dome-habitation-5-1.cfg
+++ b/GameData/StationPartsExpansionRedux/Parts/Rigid/station-5/sspx-dome-habitation-5-1.cfg
@@ -18,7 +18,7 @@ PART
 	MODEL
 	{
 		model = StationPartsExpansionRedux/Parts/Common/sspx-endcap-5-solid-1
-		position = 0.0,  -1.086, 0.0
+		position = 0.0,  -1.08037, 0.0
 		scale = 1,-1,1
 		rotation = 0, 0, 0
 	}
@@ -28,12 +28,12 @@ PART
 
 	// --- node definitions ---
 	
-	node_stack_bottom = 0.0, -1.086, 0.0, 0.0, -1.0, 0.0, 4
+	node_stack_bottom = 0.0, -1.08037, 0.0, 0.0, -1.0, 0.0, 4
   node_stack_south =  0, -0.29, -2.54, 0.0, 0.0, -1.0, 1
   node_stack_north =  0, -0.29, 2.54, 0.0, 0.0, 1.0, 1
   node_stack_west =  -2.54, -0.29, 0.0, -1.0, 0.0, 0.0, 1
   node_stack_east =  2.54, -0.29, 0.0, 1.0, 0.0, 0.0, 1
-  node_attach =  0.0, -1.086, 0.0, 0.0, -1.0, 0.0, 4
+  node_attach =  0.0, -1.08037, 0.0, 0.0, -1.0, 0.0, 4
 
 	// --- editor parameters ---
 	TechRequired = advScienceTech

--- a/GameData/StationPartsExpansionRedux/Parts/Rigid/station-5/sspx-greenhouse-5-1.cfg
+++ b/GameData/StationPartsExpansionRedux/Parts/Rigid/station-5/sspx-greenhouse-5-1.cfg
@@ -18,14 +18,14 @@ PART
 	MODEL
 	{
 		model = StationPartsExpansionRedux/Parts/Common/sspx-endcap-5-solid-1-mirrored
-		position = 0.0,  -2.240091, 0.0
+		position = 0.0,  -2.23956, 0.0
 		scale = 1,1,1
 		rotation = 0, 0, 0
 	}
 	MODEL
 	{
 		model = StationPartsExpansionRedux/Parts/Common/sspx-endcap-5-solid-1
-		position = 0.0, 2.359374, 0.0
+		position = 0.0, 2.35897, 0.0
 		scale = 1,1,1
 		rotation = 0, 0, 0
 	}
@@ -33,8 +33,8 @@ PART
 	rescaleFactor = 1
 
 	// --- node definitions ---
-	node_stack_top = 0.0, 2.359374, 0.0, 0.0, 1.0, 0.0, 4
-	node_stack_bottom = 0.0, -2.240091, 0.0, 0.0, -1.0, 0.0, 4
+	node_stack_top = 0.0, 2.35897, 0.0, 0.0, 1.0, 0.0, 4
+	node_stack_bottom = 0.0, -2.23956, 0.0, 0.0, -1.0, 0.0, 4
 
 
 	// --- editor parameters ---

--- a/GameData/StationPartsExpansionRedux/Parts/Rigid/station-5/sspx-habitation-5-1.cfg
+++ b/GameData/StationPartsExpansionRedux/Parts/Rigid/station-5/sspx-habitation-5-1.cfg
@@ -18,14 +18,14 @@ PART
 	MODEL
 	{
 		model = StationPartsExpansionRedux/Parts/Common/sspx-endcap-5-solid-1-mirrored
-		position = 0.0,  -2.270139, 0.0
+		position = 0.0,  -2.27243, 0.0
 		scale = 1,1,1
 		rotation = 0, 0, 0
 	}
 	MODEL
 	{
 		model = StationPartsExpansionRedux/Parts/Common/sspx-endcap-5-solid-1
-		position = 0.0, 2.348691, 0.0
+		position = 0.0, 2.34735, 0.0
 		scale = 1,1,1
 		rotation = 0, 0, 0
 	}
@@ -33,8 +33,8 @@ PART
 	rescaleFactor = 1
 
 	// --- node definitions ---
-	node_stack_top = 0.0, 2.348691, 0.0, 0.0, 1.0, 0.0, 4
-	node_stack_bottom = 0.0, -2.270139, 0.0, 0.0, -1.0, 0.0, 4
+	node_stack_top = 0.0, 2.34735, 0.0, 0.0, 1.0, 0.0, 4
+	node_stack_bottom = 0.0, -2.27243, 0.0, 0.0, -1.0, 0.0, 4
 
 
 	// --- editor parameters ---

--- a/GameData/StationPartsExpansionRedux/Parts/Rigid/station-5/sspx-habitation-5-2.cfg
+++ b/GameData/StationPartsExpansionRedux/Parts/Rigid/station-5/sspx-habitation-5-2.cfg
@@ -18,14 +18,14 @@ PART
 	MODEL
 	{
 		model = StationPartsExpansionRedux/Parts/Common/sspx-endcap-5-solid-1-mirrored
-		position = 0.0,  -0.7702011, 0.0
+		position = 0.0,  -0.757123, 0.0
 		scale = 1,1,1
 		rotation = 0, 0, 0
 	}
 	MODEL
 	{
 		model = StationPartsExpansionRedux/Parts/Common/sspx-endcap-5-solid-1
-		position = 0.0, 0.6916801, 0.0
+		position = 0.0, 0.688977, 0.0
 		scale = 1,1,1
 		rotation = 0, 0, 0
 	}
@@ -33,8 +33,8 @@ PART
 	rescaleFactor = 1
 
 	// --- node definitions ---
-	node_stack_top = 0.0, 0.6916801, 0.0, 0.0, 1.0, 0.0, 4
-	node_stack_bottom = 0.0, -0.7702011, 0.0, 0.0, -1.0, 0.0, 4
+	node_stack_top = 0.0, 0.688977, 0.0, 0.0, 1.0, 0.0, 4
+	node_stack_bottom = 0.0, -0.757123, 0.0, 0.0, -1.0, 0.0, 4
 
 
 	// --- editor parameters ---

--- a/GameData/StationPartsExpansionRedux/Parts/Rigid/station-5/sspx-lab-5-1.cfg
+++ b/GameData/StationPartsExpansionRedux/Parts/Rigid/station-5/sspx-lab-5-1.cfg
@@ -18,7 +18,7 @@ PART
 	MODEL
 	{
 		model = StationPartsExpansionRedux/Parts/Common/sspx-endcap-5-solid-1
-		position = 0.0, 2.016, 0.0
+		position = 0.0, 2.018, 0.0
 		scale = 1,1,1
 		rotation = 0, 0, 0
 	}
@@ -26,7 +26,7 @@ PART
 	rescaleFactor = 1
 
 	// --- node definitions ---
-	node_stack_top = 0.0, 2.016, 0.0, 0.0, 1.0, 0.0, 4
+	node_stack_top = 0.0, 2.018, 0.0, 0.0, 1.0, 0.0, 4
 	node_stack_bottom = 0.0, -1.914, 0.0, 0.0, -1.0, 0.0, 4
 
 

--- a/GameData/StationPartsExpansionRedux/Parts/Rigid/station-5/sspx-logistics-5-1.cfg
+++ b/GameData/StationPartsExpansionRedux/Parts/Rigid/station-5/sspx-logistics-5-1.cfg
@@ -12,8 +12,8 @@ PART
 
 	// --- node definitions ---
 	// definition format is Position X, Position Y, Position Z, Up X, Up Y, Up Z
-	node_stack_bottom = 0.0, -2.3, 0.0, 0.0, -1.0, 0.0, 4
-	node_stack_top = 0.0,2.43, 0.0, 0.0, 1.0, 0.0, 4
+	node_stack_bottom = 0.0, -2.30211, 0.0, 0.0, -1.0, 0.0, 4
+	node_stack_top = 0.0, 2.42913, 0.0, 0.0, 1.0, 0.0, 4
 	MODEL
 	{
 		model = StationPartsExpansionRedux/Parts/Rigid/station-5/sspx-logistics-5-1
@@ -25,14 +25,14 @@ PART
   MODEL
   {
     model = StationPartsExpansionRedux/Parts/Common/sspx-endcap-5-solid-1-mirrored
-    position = 0.0,  -2.3, 0.0
+    position = 0.0,  -2.30211, 0.0
     scale = 1,1,1
     rotation = 0, 0, 0
   }
   MODEL
   {
     model = StationPartsExpansionRedux/Parts/Common/sspx-endcap-5-solid-1
-    position = 0.0, 2.43, 0.0
+    position = 0.0, 2.42913, 0.0
     scale = 1,1,1
     rotation = 0, 0, 0
   }

--- a/GameData/StationPartsExpansionRedux/Parts/Rigid/station-5/sspx-logistics-5-2.cfg
+++ b/GameData/StationPartsExpansionRedux/Parts/Rigid/station-5/sspx-logistics-5-2.cfg
@@ -12,8 +12,8 @@ PART
 
 	// --- node definitions ---
 	// definition format is Position X, Position Y, Position Z, Up X, Up Y, Up Z
-	node_stack_bottom = 0.0, -1.173155, 0.0, 0.0, -1.0, 0.0, 4
-	node_stack_top = 0.0, 1.43231, 0.0, 0.0, 1.0, 0.0, 4
+	node_stack_bottom = 0.0, -1.17178, 0.0, 0.0, -1.0, 0.0, 4
+	node_stack_top = 0.0, 1.42697, 0.0, 0.0, 1.0, 0.0, 4
 	MODEL
 	{
 		model = StationPartsExpansionRedux/Parts/Rigid/station-5/sspx-logistics-5-2
@@ -25,14 +25,14 @@ PART
   MODEL
   {
     model = StationPartsExpansionRedux/Parts/Common/sspx-endcap-5-solid-1-mirrored
-    position = 0.0, -1.173155, 0.0
+    position = 0.0, -1.17178, 0.0
     scale = 1,1,1
     rotation = 0, 0, 0
   }
   MODEL
   {
     model = StationPartsExpansionRedux/Parts/Common/sspx-endcap-5-solid-1
-    position = 0.0, 1.43231, 0.0
+    position = 0.0, 1.42697, 0.0
     scale = 1,1,1
     rotation = 0, 0, 0
   }


### PR DESCRIPTION
Updates the positions of the endcaps for the 5m parts, along with the associated stack nodes, so they are flush with the main mesh. Fixes #302  (except for the gap in the Lab mesh)

The extra height on the end faces of the caps should cover up any gaps made on existing craft.