### PR TITLE
Fix missing `affectDragCubes = false` B9PS entries causing various issues.

### DIFF
--- a/GameData/StationPartsExpansionRedux/Parts/Extendable/extendable-375/sspx-expandable-centrifuge-375-1.cfg
+++ b/GameData/StationPartsExpansionRedux/Parts/Extendable/extendable-375/sspx-expandable-centrifuge-375-1.cfg
@@ -312,6 +312,7 @@ PART
     name = ModuleB9PartSwitch
     moduleID = endcapSwitch2
     switcherDescription = #LOC_SSPX_Switcher_EndcapsLower_Name
+    affectDragCubes = false
 
      SUBTYPE
     {

--- a/GameData/StationPartsExpansionRedux/Parts/Extendable/extendable-375/sspx-expandable-centrifuge-375-2.cfg
+++ b/GameData/StationPartsExpansionRedux/Parts/Extendable/extendable-375/sspx-expandable-centrifuge-375-2.cfg
@@ -315,6 +315,7 @@ PART
     name = ModuleB9PartSwitch
     moduleID = endcapSwitch2
     switcherDescription = #LOC_SSPX_Switcher_EndcapsLower_Name
+    affectDragCubes = false
 
      SUBTYPE
     {

--- a/GameData/StationPartsExpansionRedux/Parts/Extendable/extendable-5/sspx-expandable-centrifuge-5-1.cfg
+++ b/GameData/StationPartsExpansionRedux/Parts/Extendable/extendable-5/sspx-expandable-centrifuge-5-1.cfg
@@ -275,6 +275,8 @@ PART
     name = ModuleB9PartSwitch
     moduleID = endcapSwitch2
     switcherDescription = #LOC_SSPX_Switcher_EndcapsLower_Name
+    affectDragCubes = false
+    
     SUBTYPE
     {
       name = BlackHandles


### PR DESCRIPTION
Some SSPX configs missing `affectDragCubes = false` entries on some B9PS modules.
Any part that has a `ModuleDeployableCentrifuge` or `ModuleDeployableHabitat`, and also one or more `ModuleB9PartSwitch` where some `transform` are switched must define `affectDragCubes = false` in those B9PS modules to prevent B9PS generating additional procedural drag cubes that will interfere with the non-procedural ones defined in the SSPX deployable modules.

Failing to doing so results in the following log entries on part load : 
```
[ERROR] [Part sspx-expandable-centrifuge-5-1] [ModuleB9PartSwitch 'endcapSwitch2'] Cannot reassign cube weights: had 2 cubes before but now have 4.
```
Apart from making the drag cubes wrong (and consequently aero/thermal part properties), it can produce kraken-like events under specific circumstances as reported in https://github.com/KSPModdingLibs/KSPCommunityFixes/issues/119